### PR TITLE
s1kd-appcheck: Improve nested check

### DIFF
--- a/tools/common/s1kd_tools.h
+++ b/tools/common/s1kd_tools.h
@@ -206,4 +206,16 @@ bool is_cir(const char *path, const bool ignore_del);
 /* Remove elements marked as "delete". */
 void rem_delete_elems(xmlDocPtr doc);
 
+/* Tests whether ident:type=value was defined by the user */
+bool is_applic(xmlNodePtr defs, const char *ident, const char *type, const char *value, bool assume);
+
+/* Tests whether an <assert> element is applicable */
+bool eval_assert(xmlNodePtr defs, xmlNodePtr assert, bool assume);
+
+/* Test whether an <evaluate> element is applicable. */
+bool eval_evaluate(xmlNodePtr defs, xmlNodePtr evaluate, bool assume);
+
+/* Generic test for either <assert> or <evaluate> */
+bool eval_applic(xmlNodePtr defs, xmlNodePtr node, bool assume);
+
 #endif

--- a/tools/s1kd-instance/s1kd-instance.c
+++ b/tools/s1kd-instance/s1kd-instance.c
@@ -17,7 +17,7 @@
 #include "xsl.h"
 
 #define PROG_NAME "s1kd-instance"
-#define VERSION "12.2.2"
+#define VERSION "12.2.3"
 
 /* Prefixes before messages printed to console */
 #define ERR_PREFIX PROG_NAME ": ERROR: "
@@ -550,181 +550,6 @@ static void free_ident(struct ident *ident)
 	}
 }
 
-/* Evaluate an applic statement, returning whether it is valid or invalid given
- * the user-supplied applicability settings.
- *
- * If assume is true, undefined attributes and conditions are ignored. This is
- * primarily useful for determining which elements are not applicable in content
- * and may be removed.
- *
- * If assume is false, undefined attributes or conditions will cause an applic
- * statement to evaluate as invalid. This is primarily useful for determining
- * which applic statements and references are unambiguously true (they do not
- * rely on any undefined attributes or conditions) and therefore may be removed.
- *
- * An undefined attribute/condition is a product attribute (ACT) or
- * condition (CCT) for which a value is asserted in the applic statement but
- * for which no value was supplied by the user.
- */
-static bool eval_applic(xmlNodePtr defs, xmlNodePtr node, bool assume);
-
-/* Evaluate multiple values for a property */
-static bool eval_multi(xmlNodePtr multi, const char *ident, const char *type, const char *value)
-{
-	xmlNodePtr cur;
-	bool result = false;
-
-	for (cur = multi->children; cur; cur = cur->next) {
-		xmlChar *cur_value;
-		bool in_set;
-
-		cur_value = xmlNodeGetContent(cur);
-		in_set = is_in_set((char *) cur_value, value);
-		xmlFree(cur_value);
-
-		if (in_set) {
-			result = true;
-			break;
-		}
-	}
-
-	return result;
-}
-
-/* Tests whether ident:type=value was defined by the user */
-static bool is_applic(xmlNodePtr defs, const char *ident, const char *type, const char *value, bool assume)
-{
-	xmlNodePtr cur;
-
-	bool result = assume;
-
-	if (!(ident && type && value)) {
-		return assume;
-	}
-
-	for (cur = defs->children; cur; cur = cur->next) {
-		char *cur_ident = (char *) xmlGetProp(cur, BAD_CAST "applicPropertyIdent");
-		char *cur_type  = (char *) xmlGetProp(cur, BAD_CAST "applicPropertyType");
-		char *cur_value = (char *) xmlGetProp(cur, BAD_CAST "applicPropertyValues");
-
-		bool match = strcmp(cur_ident, ident) == 0 && strcmp(cur_type, type) == 0;
-
-		if (match) {
-			if (cur_value) {
-				result = is_in_set(cur_value, value);
-			} else if (assume) {
-				result = eval_multi(cur, ident, type, value);
-			}
-		}
-
-		xmlFree(cur_ident);
-		xmlFree(cur_type);
-		xmlFree(cur_value);
-
-		if (match) {
-			break;
-		}
-
-	}
-
-	return result;
-}
-
-/* Tests whether an <assert> element is applicable */
-static bool eval_assert(xmlNodePtr defs, xmlNodePtr assert, bool assume)
-{
-	xmlNodePtr ident_attr, type_attr, values_attr;
-	char *ident, *type, *values;
-
-	bool ret;
-
-	ident_attr  = first_xpath_node(NULL, assert, BAD_CAST "@applicPropertyIdent|@actidref");
-	type_attr   = first_xpath_node(NULL, assert, BAD_CAST "@applicPropertyType|@actreftype");
-	values_attr = first_xpath_node(NULL, assert, BAD_CAST "@applicPropertyValues|@actvalues");
-
-	ident  = (char *) xmlNodeGetContent(ident_attr);
-	type   = (char *) xmlNodeGetContent(type_attr);
-	values = (char *) xmlNodeGetContent(values_attr);
-
-	ret = is_applic(defs, ident, type, values, assume);
-
-	xmlFree(ident);
-	xmlFree(type);
-	xmlFree(values);
-
-	return ret;
-}
-
-enum operator { AND, OR };
-
-/* Test whether an <evaluate> element is applicable. */
-static bool eval_evaluate(xmlNodePtr defs, xmlNodePtr evaluate, bool assume)
-{
-	xmlChar *andOr;
-	enum operator op;
-	bool ret = assume;
-	xmlNodePtr cur;
-
-	andOr = first_xpath_value(NULL, evaluate, BAD_CAST "@andOr|@operator");
-
-	if (!andOr) {
-		if (verbosity > QUIET) {
-			fprintf(stderr, S_MISSING_ANDOR);
-		}
-		exit(EXIT_BAD_XML);
-	}
-
-	if (xmlStrcmp(andOr, BAD_CAST "and") == 0) {
-		op = AND;
-	} else {
-		op = OR;
-	}
-
-	xmlFree(andOr);
-
-	for (cur = evaluate->children; cur; cur = cur->next) {
-		if (xmlStrcmp(cur->name, BAD_CAST "assert") == 0 || xmlStrcmp(cur->name, BAD_CAST "evaluate") == 0) {
-			ret = eval_applic(defs, cur, assume);
-
-			if ((op == AND && !ret) || (op == OR && ret)) {
-				break;
-			}
-		}
-	}
-
-	return ret;
-}
-
-/* Generic test for either <assert> or <evaluate> */
-static bool eval_applic(xmlNodePtr defs, xmlNodePtr node, bool assume)
-{
-	if (strcmp((char *) node->name, "assert") == 0) {
-		return eval_assert(defs, node, assume);
-	} else if (strcmp((char *) node->name, "evaluate") == 0) {
-		return eval_evaluate(defs, node, assume);
-	}
-
-	return false;
-}
-
-/* Tests whether an <applic> element is true. */
-static bool eval_applic_stmt(xmlNodePtr defs, xmlNodePtr applic, bool assume)
-{
-	xmlNodePtr stmt;
-
-	stmt = find_child(applic, "assert");
-
-	if (!stmt) {
-		stmt = find_child(applic, "evaluate");
-	}
-
-	if (!stmt) {
-		return assume;
-	}
-
-	return eval_applic(defs, stmt, assume);
-}
-
 /* Search recursively for a descendant element with the given id */
 static xmlNodePtr get_element_by_id(xmlNodePtr root, const char *id)
 {
@@ -753,6 +578,24 @@ static xmlNodePtr get_element_by_id(xmlNodePtr root, const char *id)
 	}
 
 	return NULL;
+}
+
+/* Tests whether an <applic> element is true. */
+static bool eval_applic_stmt(xmlNodePtr defs, xmlNodePtr applic, bool assume)
+{
+	xmlNodePtr stmt;
+
+	stmt = find_child(applic, "assert");
+
+	if (!stmt) {
+		stmt = find_child(applic, "evaluate");
+	}
+
+	if (!stmt) {
+		return assume;
+	}
+
+	return eval_applic(defs, stmt, assume);
 }
 
 /* Remove non-applicable elements from content */


### PR DESCRIPTION
Improved the nested applicability check (-n) in s1kd-appcheck by using the same logic from s1kd-instance to properly evaluate the applicability of child assertions against parent assertions.